### PR TITLE
自動リトライの間隔を調整

### DIFF
--- a/src/Unityroom.Client/Assets/Unityroom.Client/Runtime/UnityroomClient.cs
+++ b/src/Unityroom.Client/Assets/Unityroom.Client/Runtime/UnityroomClient.cs
@@ -64,7 +64,8 @@ namespace Unityroom.Client
                         if (retryCount > 0)
                         {
                             retryCount--;
-                            await TaskEx.DelayOnMainThread(TimeSpan.FromSeconds(2.0), cts.Token);
+                            // unityroom側のrate_limitの仕様に合わせ、5秒間の待機を行う
+                            await TaskEx.DelayOnMainThread(TimeSpan.FromSeconds(5.0), cts.Token);
                             goto RETRY;
                         }
                     }


### PR DESCRIPTION
現在のunityroomの仕様として、api呼び出しから5秒以内のリクエストはrate_limit_exceededを返すようになっています。そのため、それに合わせて自動リトライの間隔を`TimeSpan.FromSeconds(5.0)`に変更します。